### PR TITLE
Fix machine compact format loading

### DIFF
--- a/SymbolicTM.cpp
+++ b/SymbolicTM.cpp
@@ -439,6 +439,7 @@ int main(int argc, char *argv[])
 					nr_symbols = i;
 			}
 		}
+		nr_states++;
 	}
 	else
 	{


### PR DESCRIPTION
```
SymbolicTM〉g++ -O2 -Wno-unused-result SymbolicTM.cpp; cat BB7410754.txt | ./a.out -vv                                                                        09/16/2022 09:00:32 AM
     0   1
A  1RB 0LD
B  1LC 1RC
C  1LA 0RC
D  --- 0LE

A: 0@ 0 .@ (1RB) => B: 0@1 . .@
```
->
```
SymbolicTM〉g++ -O2 -Wno-unused-result SymbolicTM.cpp; cat BB7410754.txt | ./a.out -vv                                                                        09/16/2022 09:03:07 AM
     0   1
A  1RB 0LD
B  1LC 1RC
C  1LA 0RC
D  --- 0LE
E  0RB 1LD

A: 0@ 0 .@ (1RB) => B: 0@1 . .@
```